### PR TITLE
Add additional headers to every API call

### DIFF
--- a/contentful_management/client.py
+++ b/contentful_management/client.py
@@ -97,7 +97,8 @@ class Client(object):
             application_name=None,
             application_version=None,
             integration_name=None,
-            integration_version=None):
+            integration_version=None,
+            additional_headers=None):
         self.access_token = access_token
         self.api_url = api_url
         self.uploads_api_url = uploads_api_url
@@ -117,6 +118,7 @@ class Client(object):
         self.application_version = application_version
         self.integration_name = integration_name
         self.integration_version = integration_version
+        self.additional_headers = additional_headers or {}
 
         self._validate_configuration()
 
@@ -422,6 +424,7 @@ class Client(object):
         kwargs = request_kwargs if request_kwargs is not None else {}
 
         headers = self._request_headers()
+        headers.update(self.additional_headers)
         if 'headers' in kwargs:
             headers.update(kwargs['headers'])
         kwargs['headers'] = headers

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -178,3 +178,12 @@ class ClientTest(TestCase):
             self.assertTrue(e in header)
 
         self.assertTrue(re.search('os (Windows|macOS|Linux)(\/.*)?;', header))
+
+    @vcr.use_cassette('fixtures/client/additional_headers.yaml')
+    def test_client_with_additional_headers(self):
+        client = Client(PLAYGROUND_KEY, raise_errors=False, additional_headers={'fizz': 'buzz'})
+
+        error = client.entries(PLAYGROUND_SPACE).find('abc123')
+
+        self.assertIn('fizz', error.response.request.headers)
+


### PR DESCRIPTION
#### Reasoning
Often times it is useful to add headers to HTTP requests to make debugging easier and tracing requests across a network less painful. This change could be used in combination with overriding the default values for `api_url` and `uploads_api_url` so that requests can, for example, be sent through a middleware server with custom headers attached for logging and monitoring.

#### Expected usage:
```python
from contentful_management import Client

OAUTH_TOKEN = 'my-oauth-token'
MY_HEADER = 'foobar'

client = Client(
    OAUTH_TOKEN,
    api_url='gateway.skyscanner.net/contentful-management',
    uploads_api_url='gateway.skyscanner.net/contentful-uploads',
    https=True,
    additional_headers={'my_header': MY_HEADER}
)
```