### PR TITLE
[Added] README: missing content_type_id attribute in creating a new entry

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,6 +208,7 @@ Deleting an entry::
 Creating an entry::
 
     entry_attributes = {
+        'content_type_id': 'target_content_type',
         'fields': {
             'title': {
                 'en-US': 'My Awesome Post'


### PR DESCRIPTION
The existing example doesn't show how we can specify the content type id when creating a new entry.