### PR TITLE
Docs: is_published is a property not a method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -257,7 +257,7 @@ Publishing or Unpublishing an asset::
 
 Checking if an asset is published::
 
-    asset.is_published()
+    asset.is_published
 
 Entries
 -------


### PR DESCRIPTION
As demonstrated by [this test](https://github.com/contentful/contentful-management.py/blob/master/tests/entry_test.py) and [this source](https://github.com/contentful/contentful-management.py/blob/master/contentful_management/resource.py).