### PR TITLE
Notify users about the default environment name.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,7 @@ Install Contentful Management from the Python Package Index::
 
 Usage
 -----
+**Warning, if you're using your account without environments the "_environment_id_" in the examples below should be "_master_"!**
 
 Client
 ------


### PR DESCRIPTION
It's taken me quite some discussions with support to find out how to use this. So it might be beneficial to other users to know to use *master* in advance.