### PR TITLE
Avoid detection of response encoding

### DIFF
--- a/contentful_management/client.py
+++ b/contentful_management/client.py
@@ -689,6 +689,7 @@ class Client(object):
 
         request_method = getattr(requests, method)
         response = request_method(request_url, **kwargs)
+        response.encoding = 'utf-8'
 
         if response.status_code == 429:
             raise RateLimitExceededError(response)


### PR DESCRIPTION
As API always response with UTF-8 we can avoid detection of response encoding.