### PR TITLE
Update errors.py

### DIFF
--- a/contentful_management/errors.py
+++ b/contentful_management/errors.py
@@ -126,7 +126,7 @@ class NotFoundError(HTTPError):
         if isinstance(details, string_class()):
             return details
 
-        message = "The requested {0} could not be found.".format(details['type'])
+        message = "The requested {0} could not be found.".format(details['sys']['type'])
         resource_id = details.get('id', None)
         if resource_id is not None:
             message += " ID: {0}.".format(resource_id)


### PR DESCRIPTION
The `details` dictionary doesn't contain a key `type`, resulting in a `KeyError` exception.
Instead, I've found that details has the following structure:
```python
{
    'sys': {
        'type': 'Space', 
        'id': '<space id>'
    }
}
```