### PR TITLE
Convert environment Links to json in Resource.to_json()

### DIFF
--- a/contentful_management/resource.py
+++ b/contentful_management/resource.py
@@ -164,7 +164,7 @@ class Resource(object):
         }
         for k, v in self.sys.items():
             if k in ['space', 'content_type', 'created_by',
-                     'updated_by', 'published_by']:
+                     'environment', 'updated_by', 'published_by']:
                 v = v.to_json()
             if k in ['created_at', 'updated_at', 'deleted_at',
                      'first_published_at', 'published_at', 'expires_at']:


### PR DESCRIPTION
There appears to be a bug where Entry instances aren't converting the 'environment' sys field Link instance to json when calling to_json(). 

Hopefully this solution makes sense in general, it fixed the particular issue I was having.

Demonstration [here](https://gist.github.com/MikeFE/69cdf641cafb3b35dc9223f98e346cfb).