### PR TITLE
Fixed issue where defaultValues were set to None instead of being omitted for fields in content types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 * Updated `pyyaml` version to fix a vulnerability.
+* Fixed defaultValues omit instead of None for fields in content types.
 
 ## v2.14.0
 * Adds support for cross-space references

--- a/contentful_management/content_type_field.py
+++ b/contentful_management/content_type_field.py
@@ -31,7 +31,8 @@ class ContentTypeField(object):
         self.omitted = field_data.get('omitted', False)
         self.required = field_data.get('required', False)
         self.disabled = field_data.get('disabled', False)
-        self.default_value = field_data.get('defaultValue', None)
+        if field_data.get('defaultValue', None) is not None:
+            self.default_value = field_data.get('defaultValue')
         self.validations = [ContentTypeFieldValidation(v)
                             for v in field_data.get('validations', [])]
         self.allowedResources = field_data.get('allowedResources')
@@ -51,8 +52,10 @@ class ContentTypeField(object):
             'required': self.required,
             'disabled': self.disabled,
             'validations': [v.to_json() for v in self.validations],
-            'defaultValue': self.default_value
         }
+
+        if hasattr(self, 'default_value'):
+            result['defaultValue'] = self.default_value
 
         if self.type == 'Array':
             result['items'] = self.items

--- a/tests/content_type_field_test.py
+++ b/tests/content_type_field_test.py
@@ -42,6 +42,13 @@ FIELD_WITH_VALIDATIONS = {
     ]
 }
 
+FIELD_WITH_DEFAULT_VALUE = {
+    'name': 'foo',
+    'id': 'foo',
+    'type': 'Symbol',
+    'defaultValue': 'bar'
+}
+
 class ContentTypeFieldTest(TestCase):
     def test_simple_field_test(self):
         field = ContentTypeField(SIMPLE_FIELD)
@@ -56,7 +63,6 @@ class ContentTypeFieldTest(TestCase):
             'required': False,
             'disabled': False,
             'validations': [],
-            'defaultValue': None
         })
 
     def test_link_field_test(self):
@@ -73,7 +79,6 @@ class ContentTypeFieldTest(TestCase):
             'required': False,
             'disabled': False,
             'validations': [],
-            'defaultValue': None
         })
 
     def test_array_field_test(self):
@@ -91,8 +96,7 @@ class ContentTypeFieldTest(TestCase):
             'omitted': False,
             'required': False,
             'disabled': False,
-            'validations': [],
-            'defaultValue': None
+            'validations': []
         })
 
     def test_link_array_field_test(self):
@@ -112,7 +116,6 @@ class ContentTypeFieldTest(TestCase):
             'required': False,
             'disabled': False,
             'validations': [],
-            'defaultValue': None
         })
 
     def test_validations_field_test(self):
@@ -130,10 +133,25 @@ class ContentTypeFieldTest(TestCase):
             'validations': [{
                 'size': {'min': 3}
             }],
-            'defaultValue': None
         })
 
     def test_coercion(self):
         field = ContentTypeField(SIMPLE_FIELD)
 
         self.assertEqual(field.coerce(123), '123')
+
+    def test_default_value_test(self):
+        field = ContentTypeField(FIELD_WITH_DEFAULT_VALUE)
+
+        self.assertEqual(str(field), "<ContentTypeField[foo] id='foo' type='Symbol'>")
+        self.assertEqual(field.to_json(), {
+            'id': 'foo',
+            'name': 'foo',
+            'type': 'Symbol',
+            'localized': False,
+            'omitted': False,
+            'required': False,
+            'disabled': False,
+            'validations': [],
+            'defaultValue': 'bar'
+        })

--- a/tests/content_type_test.py
+++ b/tests/content_type_test.py
@@ -62,7 +62,6 @@ class ContentTypeTest(TestCase):
                     'required': False,
                     'disabled': False,
                     'validations': [],
-                    'defaultValue': None
                 }
             ]
         })

--- a/tests/snapshot_test.py
+++ b/tests/snapshot_test.py
@@ -176,7 +176,6 @@ class SnapshotTest(TestCase):
                         "omitted": False,
                         "type": "Text",
                         "validations": [],
-                        "defaultValue": None
                     },
                     {
                         "id": "body",
@@ -187,7 +186,6 @@ class SnapshotTest(TestCase):
                         "omitted": False,
                         "type": "Text",
                         "validations": [],
-                        "defaultValue": None
                     }
                 ],
                 "sys": {


### PR DESCRIPTION
Fixes #116 