### PR TITLE
fix: remove invalid global and add comments to suppress warnings [PY-94]

### DIFF
--- a/contentful_management/utils.py
+++ b/contentful_management/utils.py
@@ -44,7 +44,7 @@ def string_class():
     depends on the Python version."""
     if sys.version_info[0] >= 3:
         return str
-    return basestring
+    return basestring # noqa: F821
 
 
 def json_error_class():
@@ -185,7 +185,7 @@ def str_type():
     if sys.version_info[0] >= 3:
         return str
 
-    return basestring
+    return basestring # noqa: F821
 
 
 def sanitize_date(date):

--- a/contentful_management/utils.py
+++ b/contentful_management/utils.py
@@ -185,7 +185,6 @@ def str_type():
     if sys.version_info[0] >= 3:
         return str
 
-    global basestring
     return basestring
 
 


### PR DESCRIPTION
The use of `global basestring` is incorrect. We are not assigning a value to `global` within the same scope, we are only referencing it, we can remove this line.  Additionally seeing linting errors saying that basestring is undefined, so telling Flake8 to ignore this since it will only get called when Python version 2 is being used.