### PR TITLE
chore: rename team-tundra -> team-extensibility [EXT-6372]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @contentful/team-tundra
+* @contentful/team-tundra @contentful/team-developer-experience

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -27,4 +27,4 @@ spec:
   lifecycle: unknown  
   system: unknown #optional
   # your team name as it appears in github when tagging them for reviews
-  owner: group:team-tundra
+  owner: group:team-developer-experience


### PR DESCRIPTION
We recently renamed our team in work day and that finally synced in github.
team-tundra -> team-extensibility