### PR TITLE
Feature/taxonomy concepts with linting fix

### DIFF
--- a/contentful_management/client.py
+++ b/contentful_management/client.py
@@ -586,12 +586,16 @@ class Client(object):
     def taxonomy_concept_schemes(self, organization_id):
         """
         Provides access to taxonomy concept scheme management methods.
+
         API reference: https://www.contentful.com/developers/docs/references/content-management-api/#/reference/taxonomy/concept-scheme
+
         :param organization_id: The ID of the organization.
         :type organization_id: string
         :return: :class:`TaxonomyConceptSchemesProxy <contentful_management.taxonomy_concept_schemes_proxy.TaxonomyConceptSchemesProxy>` object.
         :rtype: contentful_management.taxonomy_concept_schemes_proxy.TaxonomyConceptSchemesProxy
+
         Usage:
+
             >>> taxonomy_concept_schemes_proxy = client.taxonomy_concept_schemes('organization_id')
             <TaxonomyConceptSchemesProxy organization_id="organization_id">
         """


### PR DESCRIPTION
Fix linting error in previous [commit/PR](https://github.com/contentful/contentful-management.py/pull/132)

```bash
// Full pdm release command output
pdm run release
Creating file _docs/contentful_management.rst.
Creating file _docs/modules.rst.
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v7.1.2
WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).
making output directory... done
WARNING: html_static_path entry '_static' does not exist
building [mo]: targets for 0 po files that are out of date
writing output...
building [html]: targets for 3 source files that are out of date
updating environment: [new config] 3 added, 0 changed, 0 removed
reading sources... [100%] modules
/Users/ethan.ozelius/Development/contentful-management.py/contentful_management/client.py:docstring of contentful_management.client.Client.taxonomy_concept_schemes:8: ERROR: Unexpected indentation.
/Users/ethan.ozelius/Development/contentful-management.py/contentful_management/environment_resource_proxy.py:docstring of contentful_management.environment_resource_proxy:2: WARNING: Title underline too short.

contentful_management.environment_resource_proxy
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... copying static files... done
copying extra files... done
done
writing output... [100%] modules
generating indices... genindex py-modindex done
highlighting module code... [100%] contentful_management.webhooks_proxy
writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 4 warnings.

The HTML pages are in _build/html.

Build finished. The HTML pages are in _build/html.
[master 5f9d71e] Bump to version 2.15.0
 Date: Mon Sep 22 15:14:33 2025 -0600
 99 files changed, 1714 insertions(+), 183 deletions(-)
 create mode 100644 docs/_modules/contentful_management/content_type_metadata.html
 create mode 100644 docs/_modules/contentful_management/taxonomy_concept.html
 create mode 100644 docs/_modules/contentful_management/taxonomy_concept_scheme.html
 create mode 100644 docs/_modules/contentful_management/taxonomy_concept_schemes_proxy.html
 create mode 100644 docs/_modules/contentful_management/taxonomy_concepts_proxy.html
Building sdist...
See /Users/ethan.ozelius/Library/Logs/pdm/pdm-build-zu0js2at.log for detailed debug log.
[ExtraData]: unpack(b) received extra data.
WARNING: Add '-v' to see the detailed traceback
```