### PR TITLE
feat(usage): deprecate legacy periodic-usage endpoints [MOI-7250]

### DIFF
--- a/contentful_management/client.py
+++ b/contentful_management/client.py
@@ -1,5 +1,6 @@
 import requests
 import platform
+import warnings
 from re import sub
 
 from .resource_builder import ResourceBuilder
@@ -202,7 +203,20 @@ class Client(object):
 
             >>> organization_periodic_usages = client.organization_periodic_usages('organization_id')
             <OrganizationPeriodicUsagesProxy organization_id='organization_id'>
+
+        .. deprecated::
+            The ``GET /organizations/:organization_id/organization_periodic_usages``
+            endpoint is deprecated in favor of the new Usage API. It will be
+            removed on 2027-02-28, after which requests will return 410 Gone.
         """
+
+        warnings.warn(
+            "client.organization_periodic_usages() calls the legacy "
+            "organization_periodic_usages endpoint, which is deprecated and will "
+            "be removed on 2027-02-28. Migrate to the new Usage API.",
+            DeprecationWarning,
+            stacklevel=2
+        )
 
         return OrganizationPeriodicUsagesProxy(self, organization_id)
 
@@ -219,7 +233,20 @@ class Client(object):
 
             >>> space_periodic_usages = client.space_periodic_usages('organization_id')
             <SpacePeriodicUsagesProxy organization_id='organization_id'>
+
+        .. deprecated::
+            The ``GET /organizations/:organization_id/space_periodic_usages``
+            endpoint is deprecated in favor of the new Usage API. It will be
+            removed on 2027-02-28, after which requests will return 410 Gone.
         """
+
+        warnings.warn(
+            "client.space_periodic_usages() calls the legacy "
+            "space_periodic_usages endpoint, which is deprecated and will be "
+            "removed on 2027-02-28. Migrate to the new Usage API.",
+            DeprecationWarning,
+            stacklevel=2
+        )
 
         return SpacePeriodicUsagesProxy(self, organization_id)
 

--- a/contentful_management/organization_periodic_usage.py
+++ b/contentful_management/organization_periodic_usage.py
@@ -17,6 +17,11 @@ API reference: https://www.contentful.com/developers/docs/references/content-man
 class OrganizationPeriodicUsage(Resource):
     """
     API reference: https://www.contentful.com/developers/docs/references/content-management-api/#/reference/usage
+
+    .. deprecated::
+        Backed by the legacy organization_periodic_usages endpoint, which is
+        deprecated in favor of the new Usage API and will be removed on
+        2027-02-28.
     """
 
     def __init__(self, item, **kwargs):

--- a/contentful_management/organization_periodic_usages_proxy.py
+++ b/contentful_management/organization_periodic_usages_proxy.py
@@ -18,6 +18,11 @@ API reference: https://www.contentful.com/developers/docs/references/content-man
 class OrganizationPeriodicUsagesProxy(ClientProxy):
     """
     API reference: https://www.contentful.com/developers/docs/references/content-management-api/#/reference/usage
+
+    .. deprecated::
+        This proxy wraps the legacy organization_periodic_usages endpoint,
+        which is deprecated in favor of the new Usage API and will be
+        removed on 2027-02-28.
     """
 
     def __init__(self, client, organization_id):
@@ -31,6 +36,11 @@ class OrganizationPeriodicUsagesProxy(ClientProxy):
     def all(self, query=None, *args, **kwargs):
         """
         Gets all organization periodic usage.
+
+        .. deprecated::
+            Calls the legacy organization_periodic_usages endpoint, which is
+            deprecated in favor of the new Usage API and will be removed on
+            2027-02-28.
         """
 
         if query is None:

--- a/contentful_management/space_periodic_usage.py
+++ b/contentful_management/space_periodic_usage.py
@@ -17,6 +17,11 @@ API reference: https://www.contentful.com/developers/docs/references/content-man
 class SpacePeriodicUsage(Resource):
     """
     API reference: https://www.contentful.com/developers/docs/references/content-management-api/#/reference/usage
+
+    .. deprecated::
+        Backed by the legacy space_periodic_usages endpoint, which is
+        deprecated in favor of the new Usage API and will be removed on
+        2027-02-28.
     """
 
     def __init__(self, item, **kwargs):

--- a/contentful_management/space_periodic_usages_proxy.py
+++ b/contentful_management/space_periodic_usages_proxy.py
@@ -18,6 +18,11 @@ API reference: https://www.contentful.com/developers/docs/references/content-man
 class SpacePeriodicUsagesProxy(ClientProxy):
     """
     API reference: https://www.contentful.com/developers/docs/references/content-management-api/#/reference/usage
+
+    .. deprecated::
+        This proxy wraps the legacy space_periodic_usages endpoint, which is
+        deprecated in favor of the new Usage API and will be removed on
+        2027-02-28.
     """
 
     def __init__(self, client, organization_id):
@@ -31,6 +36,11 @@ class SpacePeriodicUsagesProxy(ClientProxy):
     def all(self, query=None, *args, **kwargs):
         """
         Gets all organization periodic usage grouped by space.
+
+        .. deprecated::
+            Calls the legacy space_periodic_usages endpoint, which is
+            deprecated in favor of the new Usage API and will be removed on
+            2027-02-28.
         """
 
         if query is None:


### PR DESCRIPTION
Ticket: https://contentful.atlassian.net/browse/MOI-7250 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR deprecates the legacy organization_periodic_usages and space_periodic_usages endpoints in the Contentful Management Python SDK. Deprecation warnings are added to the client methods, and documentation notices are added to all related resource and proxy classes, signaling migration to the new Usage API.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds runtime DeprecationWarning to client.organization_periodic_usages() and client.space_periodic_usages() methods in client.py, instructing users to migrate to the new Usage API</li>

<li>Adds docstring deprecation notices to OrganizationPeriodicUsage and SpacePeriodicUsage resource classes indicating they are backed by deprecated endpoints</li>

<li>Adds docstring deprecation notices to OrganizationPeriodicUsagesProxy and SpacePeriodicUsagesProxy classes and their all() methods</li>

<li>All deprecated endpoints scheduled for removal on 2027-02-28, after which requests will return HTTP 410 Gone</li>

</ul>
</details>

</div>